### PR TITLE
more sane stock levels defaults

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -327,6 +327,8 @@ define uber::instance
   $panels_email = "MAGFest Panels <panels@magfest.org>",
   $developer_email = "Eli Courtwright <code@magfest.org>",
 
+  $supporter_stock = undef,
+
   # rockage-specific stuff
   $student_discount = 0,
   $collect_interests = true,
@@ -337,9 +339,8 @@ define uber::instance
   $site_types = undef,
   $camping_types = undef,
   $coming_as_types = undef,
-  $supporter_stock = 10,
-  $food_stock      = 10,
-  $food_price      = 50,
+  $food_stock      = undef,
+  $food_price      = undef,
 
   $use_sanitized_development_ini = false,
   $debugONLY_dont_init_python_or_git_repos_or_plugins = false, # NEVER set in production

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -128,9 +128,18 @@ initial_attendee = '<%= @initial_attendee %>'
 shirt_level     = <%= @shirt_level %>
 supporter_level = <%= @supporter_level %>
 season_level    = <%= @season_level %>
+
+<% if @supporter_stock -%>
 supporter_stock = <%= @supporter_stock %>
+<% end -%>
+
+<% if @food_stock -%>
 food_stock      = <%= @food_stock %>
+<% end -%>
+
+<% if @food_price -%>
 food_price      = <%= @food_price %>
+<% end -%>
 
 [[donation_tier]]
 <% @donation_tier.each do |item| -%>


### PR DESCRIPTION
- don't set stock levels for supporters or magstock-specific food options unless they're set from hiera
- leave them blank if not set

fixes the issue we're having in production right now where we ran out of supporter badges because the default is 10.  This sets the default to unlimited.
