### PR TITLE
fix busted default ribbons

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -270,7 +270,7 @@ define uber::instance
   $default_table_price = 100,
   $table_prices = [],
   $event_timezone = "US/Eastern",
-  $donation_tier = [ 
+  $donation_tier = [
     "'No thanks' = 0",
     "'Ribbon' = 5",
     "'Button' = 10",
@@ -281,10 +281,7 @@ define uber::instance
     "'MPoint Holder' = 200",
     "'Lightsuit' = 500",
   ],
-  $ribbon_types = [ 
-    "press_ribbon = 'Camera'",
-    "band_ribbon = 'Rock Star'",
-  ],
+  $extra_ribbon_types = [],
   $job_interests = [
     "charity = 'Charity'",
     "con_ops = 'Operations'",
@@ -306,17 +303,17 @@ define uber::instance
     "tech_ops = 'Tech Ops'",
   ],
   $shiftless_depts = undef,
-  $interest_list = [ 
-    "console        = 'Consoles'", 
-    "arcade         = 'Arcade'", 
+  $interest_list = [
+    "console        = 'Consoles'",
+    "arcade         = 'Arcade'",
     "lan            = 'PC Gaming'",
-    "music          = 'Music'", 
+    "music          = 'Music'",
     "pabels         = 'Guests/Panels'", # TODO: fix the spelling here after m13
-    "tabletop       = 'Tabletop games'", 
-    "marketplace    = 'Dealers'", 
-    "tournaments    = 'Tournaments'", 
-    "film_fest      = 'Film Festival'", 
-    "indie_showcase = 'Indie Game Showcase'", 
+    "tabletop       = 'Tabletop games'",
+    "marketplace    = 'Dealers'",
+    "tournaments    = 'Tournaments'",
+    "film_fest      = 'Film Festival'",
+    "indie_showcase = 'Indie Game Showcase'",
     "larp           = 'LARP'",
   ],
   $event_locations = [

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -270,7 +270,7 @@ define uber::instance
   $default_table_price = 100,
   $table_prices = [],
   $event_timezone = "US/Eastern",
-  $donation_tier = [
+  $donation_tier = [ 
     "'No thanks' = 0",
     "'Ribbon' = 5",
     "'Button' = 10",
@@ -303,17 +303,17 @@ define uber::instance
     "tech_ops = 'Tech Ops'",
   ],
   $shiftless_depts = undef,
-  $interest_list = [
-    "console        = 'Consoles'",
-    "arcade         = 'Arcade'",
+  $interest_list = [ 
+    "console        = 'Consoles'", 
+    "arcade         = 'Arcade'", 
     "lan            = 'PC Gaming'",
-    "music          = 'Music'",
+    "music          = 'Music'", 
     "pabels         = 'Guests/Panels'", # TODO: fix the spelling here after m13
-    "tabletop       = 'Tabletop games'",
-    "marketplace    = 'Dealers'",
-    "tournaments    = 'Tournaments'",
-    "film_fest      = 'Film Festival'",
-    "indie_showcase = 'Indie Game Showcase'",
+    "tabletop       = 'Tabletop games'", 
+    "marketplace    = 'Dealers'", 
+    "tournaments    = 'Tournaments'", 
+    "film_fest      = 'Film Festival'", 
+    "indie_showcase = 'Indie Game Showcase'", 
     "larp           = 'LARP'",
   ],
   $event_locations = [

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -164,7 +164,7 @@ food_price      = <%= @food_price %>
 <% end -%>
 
 [[ribbon]]
-<% @ribbon_types.each do |ribbon_type| -%>
+<% @extra_ribbon_types.each do |ribbon_type| -%>
 <%= ribbon_type[0] %> = "<%= ribbon_type[1] %>"
 <% end -%>
 


### PR DESCRIPTION
default puppet value for ribbon_types should have been converted to an array, instead it was left as a string which causes weird values to show up in the INI

fixes https://github.com/magfest/ubersystem/issues/1352

 rename ribbon_types to extra_ribbon_types. because of how the configspec.ini is setup, uber will always use its internal ribbon types regardless of what you put in puppet.  therefore these ribbon types are "extra" and it's slightly less confusing. someday maybe we want to change this behavior but I think it makes sense right now.

needs to be merged with other PRs soon to come.
