### PR TITLE
force "no ribbon" to the top of the list

### DIFF
--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -164,6 +164,7 @@ food_price      = <%= @food_price %>
 <% end -%>
 
 [[ribbon]]
+no_ribbon = "no ribbon"
 <% @extra_ribbon_types.each do |ribbon_type| -%>
 <%= ribbon_type[0] %> = "<%= ribbon_type[1] %>"
 <% end -%>


### PR DESCRIPTION
because of the way we merge configspec.ini and development.ini, any extra ribbons were getting put in BEFORE "no ribbon", altering the default values for any ribbon dropdowns.   this forces "no ribbon" to the top.

this will override the existing "no ribbon" from configspec.ini with.... an exact copy of itself. so, no changes, just it will have no_ribbon at the top of the list.
