### PR TITLE
it is now possible to turn on shift signups

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class uber::config (
   $collect_full_address = false,
   #$supporter_badge_type_enabled = True,
   $prereg_open = '',
+  $shifts_created = '',
   $prereg_takedown = '',
   $uber_takedown = '',
   $epoch = '',

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -91,6 +91,7 @@ stripe_public_key = "<%= @stripe_public_key %>"
 
 [dates]
 prereg_open = '<%= @prereg_open %>'
+shifts_created = '<%= @shifts_created %>'
 shirt_deadline = '<%= @shirt_deadline %>'
 supporter_deadline = '<%= @supporter_deadline %>'
 placeholder_deadline = '<%= @placeholder_deadline %>'


### PR DESCRIPTION
Like many of our `[dates]` config options, `shifts_created` can be blank (which means emails will never be sent out).  However, there was previously no way to set it in puppet.  Now there is.
