### PR TITLE
we can now configure room deadline in puppet

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,6 +89,7 @@ class uber::config (
   $donations_enabled = true,
   $supporter_deadline = "2014-12-26",
   $placeholder_deadline = '2015-06-16',
+  $room_deadline = '',
   $shirt_deadline = '',
   $shirt_sizes = [
     "'no shirt' = 0",

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -92,6 +92,7 @@ stripe_public_key = "<%= @stripe_public_key %>"
 [dates]
 prereg_open = '<%= @prereg_open %>'
 shifts_created = '<%= @shifts_created %>'
+room_deadline = '<%= @room_deadline %>'
 shirt_deadline = '<%= @shirt_deadline %>'
 supporter_deadline = '<%= @supporter_deadline %>'
 placeholder_deadline = '<%= @placeholder_deadline %>'


### PR DESCRIPTION
Another field puppetized.

If puppet does stick around (which it probably won't if we move to Docker) then I'd _really_ like to get #28 so that we don't have to constantly make PRs once per config option every time we go to set a variable which isn't puppetized yet.  Obviously that ticket is a huge amount of work, so it's not feasible to do it anytime soon, and if we move away from puppet then it'll be a moot point.  Still, I think about it longingly every time I go to make a config change and find that the option I want to set isn't puppetized :(
