### PR TITLE
fix FQDN not being set correctly on vagrant machines

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 class uber::config (
   # sideboard config file settings only below
   $sideboard_debug_enabled = false,
-  $hostname = hiera("uber::hostname"),
+  $hostname = $uber::hostname,
   $socket_port = hiera('uber::socket_port'),
   $socket_host = '0.0.0.0',
   $ssl_port = hiera('uber::ssl_port'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,18 @@ class uber {
   $user = hiera('uber::user')
   $group = hiera('uber::group')
 
-  # TODO: don't hardcode 'python 3.4' in here, figure out how to get at that data
+  # TODO: don't hardcode 'python 3.4' in here, figure out how to generate "3.4" instead
   $venv_site_pkgs_path = "${venv_path}/lib/python3.4/site-packages"
+
+  # note: on vagrant, currently, FQDN doesn't resolve if there is no domain set.
+  # this is because the 'domain' fact returns "".
+  # if $fqdn is available, use it, if not, use $::hostname which on vagrant = "localhost"
+  #
+  # I think this is the exact same behavior as $fqdn in later versions of facter.
+  # (current version we're using is facter 1.7.5, which is pretty old shipped with Ubuntu)
+  if $::fqdn != "" {
+    $hostname = $::fqdn
+  } else {
+    $hostname = $::hostname
+  }
 }

--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -1,5 +1,5 @@
 class uber::nginx (
-  $hostname = hiera("uber::hostname"),
+  $hostname = $uber::hostname,
   $ssl_crt_bundle = 'puppet:///modules/uber/selfsigned-testonly.crt',
   $ssl_crt_key = 'puppet:///modules/uber/selfsigned-testonly.key',
   $ssl_port = hiera('uber::ssl_port'),


### PR DESCRIPTION
I now bestow upon @earl7399 the title of 'Lead QA builder' for identifying this one.

fix hostname not being correctly calculated on vagrant machines

Issue:
- this was breaking local vagrant builds
- facter doesn't set 'fqdn' fact at all if 'domain' fact isn't present
- on production nodes this was working fine because domain was fine
- on vagrant, domain wasn't set, so fqdn was "" which was causing nginx puppet (and other stuff) to crash out

To fix: puppet class uber::hostname falls back to 'hostname' if 'fqdn' isn't set.  Everything else now looks at this class for $uber::hostname.  Check out init.pp for the real fix.

I think this is actually fixed in exactly the same way in more recent versions of facter, we're using a pretty old version because it's what comes bundled on Ubuntu 14.04 .1 LTS

---

This would have been broken by the new puppet refactors because I reworked some of the hostname stuff, though, I swear I tested this with a from-scratch deploy and it worked. Weird.

Must be merged with https://github.com/magfest/ubersystem-deploy/pull/39
