### PR TITLE
priority_plugins is now configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ class uber::config (
   $socket_port = hiera('uber::socket_port'),
   $socket_host = '0.0.0.0',
   $ssl_port = hiera('uber::ssl_port'),
+  $priority_plugins = 'uber,',
 
   # ubersystem config file settings only below
   $url_prefix = 'uber',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,6 @@ class uber {
   }
 
   $plugins_dir = "${uber_path}/plugins"
-  $priority_plugins = hiera('uber::priority_plugins', 'uber,')
   $plugin_defaults = {
     'user'        => $user,
     'group'       => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class uber {
   }
 
   $plugins_dir = "${uber_path}/plugins"
+
   $plugin_defaults = {
     'user'        => $user,
     'group'       => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class uber {
   }
 
   $plugins_dir = "${uber_path}/plugins"
-
+  $priority_plugins = hiera('uber::priority_plugins', 'uber,')
   $plugin_defaults = {
     'user'        => $user,
     'group'       => $group,

--- a/templates/sb-development.ini.erb
+++ b/templates/sb-development.ini.erb
@@ -3,7 +3,7 @@
 
 # defaults to 'False'
 debug = <%= @sideboard_debug_enabled %>
-priority_plugins = uber,
+priority_plugins = <%= @priority_plugins %>
 
 [cherrypy]
 server.socket_host = <%= @socket_host %>


### PR DESCRIPTION
We're starting to need to write plugins which depend on other plugins, so it would be nice to be able to specify a plugin loading order in our config other than "uber first and then everything else in any arbitrary order".

@binary1230 I think this will do that but I'd appreciate your eyes on this.  Not urgent though.
