### PR TITLE
don't use specific version of virtualenv

### DIFF
--- a/manifests/python_setup.pp
+++ b/manifests/python_setup.pp
@@ -8,12 +8,12 @@ class uber::python_setup
       command => "pip3 install -I virtualenv",
       cwd     => $uber::uber_path,
       path    => '/usr/bin',
-      creates => "/usr/local/bin/virtualenv-3.4",
+      creates => "/usr/local/bin/virtualenv",
     }
 
     # seems puppet's virtualenv support is broken for python3, so roll our own
     exec { "uber_create_virtualenv_${name}":
-      command => "virtualenv-3.4 --always-copy ${uber::venv_path}",
+      command => "virtualenv --always-copy ${uber::venv_path}",
       cwd     => $uber::uber_path,
       path    => '/usr/local/bin',
       # test -e = file exist, test -d = dir exists


### PR DESCRIPTION
- I originally coded it this way because I thought this was the only way to force python3 (instead of python2)
- turns out that 'virtualenv' and 'virtualenv-3.4' are binary identical
- newer ubuntu boxes include virtualenv-3.5

found by magfest QA dept i.e. @earl7399 

need to test this out real quick before merging
