### PR TITLE
listen on port 4444 for API calls

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,5 +1,6 @@
 class uber::firewall (
   $ssl_port = hiera('uber::ssl_port'),
+  $ssl_api_port = hiera('uber::ssl_api_port'),
   $socket_port = hiera('uber::socket_port'),
   $http_port = '80',
   $open_backend_port = false,
@@ -14,6 +15,10 @@ class uber::firewall (
 
   ufw::allow { "${title}-ssl":
     port => $ssl_port,
+  }
+
+  ufw::allow { "${title}-ssl-api":
+    port => $ssl_api_port,
   }
 
   ufw::allow { "${title}-http":


### PR DESCRIPTION
- this was needed because enabling optional client-cert validation was causing some mobile browsers to prompt the user to enter a certificate
- normal HTTP/HTTPS traffic will happen on port 443/80 as usual, and port 4444 will be for /jsonrpc calls which are required to have a client cert validated
- everything else from last year should still work as planned
- make Vagrant and firewall also allow 4444 through

tested this locally pretty thoroughly, need to test on staging servers and setup the client certs for production for m2016
