### PR TITLE
removed hard-coded defaults in puppet variable definition

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -126,10 +126,7 @@ class uber::config (
   $shiftless_depts = undef,
   $interest_list = [],
   $event_locations = [],
-  $dept_head_overrides = [
-    "staff_support = 'Jack Boyd'",
-    "security = 'The Dorsai Irregulars'"
-  ],
+  $dept_head_overrides = [],
   $dept_head_checklist = [],
   $volunteer_checklist = [],
   $regdesk_sig = " - Victoria Earl,\nMAGFest Registration Chair",


### PR DESCRIPTION
We don't want these values showing up everywhere, we should just include the relevant stuff in production config, which I'll do separately.
