### PR TITLE
fix broken magstock INI generation

### DIFF
--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -233,35 +233,6 @@ no_ribbon = "no ribbon"
 <% end -%>
 
 
-[dept_head_checklist]
-<% if @dept_head_checklist %>
-<% Array(@dept_head_checklist).each do |checklist_section| -%>
-
-[[<%= checklist_section[0] %>]]
-<% if checklist_section[1]["name"] -%>
-name = "<%= checklist_section[1]["name"] %>"
-<% end -%>
-<% if checklist_section[1]["deadline"] -%>
-deadline = "<%= checklist_section[1]["deadline"] %>"
-<% end -%>
-<% if checklist_section[1]["description"] -%>
-description = "<%= checklist_section[1]["description"] %>"
-<% end -%>
-<% if checklist_section[1]["path"] -%>
-path = "<%= checklist_section[1]["path"] %>"
-<% end -%>
-
-<% end -%>
-<% end -%>
-
-
-[volunteer_checklist]
-<% @volunteer_checklist.each do |vc| %>
-<%= vc[0] %> = "<%= vc[1] %>"
-<% end %>
-
-
-
 <% if @noise_levels -%>
 
 # magstock-specific
@@ -317,3 +288,30 @@ path = "<%= checklist_section[1]["path"] %>"
 <% end -%>
 
 <% end -%>
+
+[dept_head_checklist]
+<% if @dept_head_checklist %>
+<% Array(@dept_head_checklist).each do |checklist_section| -%>
+
+[[<%= checklist_section[0] %>]]
+<% if checklist_section[1]["name"] -%>
+name = "<%= checklist_section[1]["name"] %>"
+<% end -%>
+<% if checklist_section[1]["deadline"] -%>
+deadline = "<%= checklist_section[1]["deadline"] %>"
+<% end -%>
+<% if checklist_section[1]["description"] -%>
+description = "<%= checklist_section[1]["description"] %>"
+<% end -%>
+<% if checklist_section[1]["path"] -%>
+path = "<%= checklist_section[1]["path"] %>"
+<% end -%>
+
+<% end -%>
+<% end -%>
+
+
+[volunteer_checklist]
+<% @volunteer_checklist.each do |vc| %>
+<%= vc[0] %> = "<%= vc[1] %>"
+<% end %>


### PR DESCRIPTION
The magstock-specific settings are intended to be put in the [integer_enums] section, but were being placed in the volunteer checklist section instead.  We never noticed we broke this because we weren't using those settings until now.

This moves the dept/volunteer checklist INI settings to the end of the INI file

this is ready to be merged, and when it is, Magstock deploys will work so we can merge:
https://github.com/magfest/simple-rams-deploy/pull/9
and
https://github.com/magfest/production-config/pull/1
