### PR TITLE
Revert "magfest2016 hack to disable a page that is behaving badly"

### DIFF
--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -44,23 +44,6 @@ class uber::nginx (
     notify   => Service["nginx"],
   }
 
-  $blackhole_config = {
-    'access_log' => 'off',
-    'deny'       => 'all'
-  }
-
-  # disable a particular page when in "at the con mode" that was causing issues.
-  # after m2016, kill this. or, keep it.
-  nginx::resource::location { "at_con_mode_hack":
-    location => "/${url_prefix}/signups/jobs",
-    ensure   => present,
-    vhost    => "rams-normal",
-    notify   => Service["nginx"],
-    www_root            => '/crap_ignore',
-    ssl      => true,
-    location_cfg_append => $blackhole_config,
-  }
-
   if ($ssl_ca_crt != undef) {
     ensure_resource('file', "${nginx::params::nx_conf_dir}/jsonrpc-client.crt", {
       owner  => $nginx::params::nx_daemon_user,


### PR DESCRIPTION
Reverts magfest/ubersystem-puppet#72

YIKES glad I remembered this, undo our desperate on-site hack that disabled the jobs page from crashing up the place.
