### PR TITLE
fix debug skip in puppet

### DIFF
--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -4,15 +4,17 @@ class uber::daemon (
 ) {
   require uber::app
 
-  supervisor::program { 'uber_daemon' :
-    ensure        => present,
-    enable        => true,
-    command       => "${uber::venv_python} sideboard/run_server.py",
-    directory     => $uber::uber_path,
-    user          => $user,
-    group         => $group,
-    logdir_mode   => '0770',
-  }
+  if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
+    supervisor::program { 'uber_daemon' :
+      ensure        => present,
+      enable        => true,
+      command       => "${uber::venv_python} sideboard/run_server.py",
+      directory     => $uber::uber_path,
+      user          => $user,
+      group         => $group,
+      logdir_mode   => '0770',
+    }
 
-  Class["uber::app"] ~> Service["supervisor::uber_daemon"]
+    Class["uber::app"] ~> Service["supervisor::uber_daemon"]
+  }
 }

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -5,23 +5,25 @@ class uber::firewall (
   $http_port = '80',
   $open_backend_port = false,
 ) {
-  include ufw
+  if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
+    include ufw
 
-  if $open_backend_port {
-    ufw::allow { "${title}-rawport":
-      port => $socket_port,
+    if $open_backend_port {
+      ufw::allow { "${title}-rawport":
+        port => $socket_port,
+      }
     }
-  }
 
-  ufw::allow { "${title}-ssl":
-    port => $ssl_port,
-  }
+    ufw::allow { "${title}-ssl":
+      port => $ssl_port,
+    }
 
-  ufw::allow { "${title}-ssl-api":
-    port => $ssl_api_port,
-  }
+    ufw::allow { "${title}-ssl-api":
+      port => $ssl_api_port,
+    }
 
-  ufw::allow { "${title}-http":
-    port => $http_port,
+    ufw::allow { "${title}-http":
+      port => $http_port,
+    }
   }
 }

--- a/manifests/permissions.pp
+++ b/manifests/permissions.pp
@@ -4,22 +4,24 @@ class uber::permissions
   $group = hiera('uber::group')
 )
 {
-  require uber::user_group
-  require uber::app
+  if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
+    require uber::user_group
+    require uber::app
 
-  # setup owner
-  exec { "setup_owner_$name":
-    command => "/bin/chown -R ${user}:${group} ${uber::uber_path}",
-    refreshonly => true,
+    # setup owner
+    exec { "setup_owner_$name":
+      command     => "/bin/chown -R ${user}:${group} ${uber::uber_path}",
+      refreshonly => true,
+    }
+
+    # setup permissions
+    $mode = 'o-rwx,g-w,u+rw'
+    exec { "setup_perms_$name":
+      command     => "/bin/chmod -R $mode ${uber::uber_path}",
+      refreshonly => true,
+    }
+
+    Class['uber::user_group'] ~> Class['uber::permissions']
+    Class['uber::app'] ~> Class['uber::permissions']
   }
-
-  # setup permissions
-  $mode = 'o-rwx,g-w,u+rw'
-  exec { "setup_perms_$name":
-    command => "/bin/chmod -R $mode ${uber::uber_path}",
-    refreshonly => true,
-  }
-
-  Class['uber::user_group'] ~> Class['uber::permissions']
-  Class['uber::app'] ~> Class['uber::permissions']
 }

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -6,10 +6,7 @@ class uber::plugins
   $sideboard_branch,
   $sideboard_plugins,
   $extra_plugins = undef,
-  $debug_skip = false,
 ) {
-  if $debug_skip == false {
-    
     # sideboard
     uber::repo { $uber::uber_path:
       source   => $sideboard_repo,
@@ -25,5 +22,4 @@ class uber::plugins
     if $extra_plugins {
       create_resources(uber::plugin, $extra_plugins, $uber::plugin_defaults)
     }
-  }
 }

--- a/manifests/python_setup.pp
+++ b/manifests/python_setup.pp
@@ -1,8 +1,7 @@
 class uber::python_setup
-(
-  $debug_skip = false,
-) {
-  if $debug_skip == false {
+()
+{
+  if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
 
     exec { "uber_install_virtualenv_${name}":
       command => "pip3 install -I virtualenv",

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,16 +7,18 @@ define uber::repo
   $revision = 'master',
 )
 {
-  include uber::install_dependencies
-  include uber::python_setup
+  if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
+    include uber::install_dependencies
+    include uber::python_setup
 
-  vcsrepo { $name:
-    ensure   => latest,
-    owner    => $owner,
-    group    => $group,
-    provider => git,
-    source   => $source,
-    revision => $revision,
-    notify   => [ Class["uber::python_setup"], Class["uber::install_dependencies"] ]
+    vcsrepo { $name:
+      ensure   => latest,
+      owner    => $owner,
+      group    => $group,
+      provider => git,
+      source   => $source,
+      revision => $revision,
+      notify   => [ Class["uber::python_setup"], Class["uber::install_dependencies"] ]
+    }
   }
 }


### PR DESCRIPTION
- this is a little uglier than I would like, but, it gives the ability to skip parts of the puppet deploy when you just want to test INI settings
- this setting is a thing we lost in the puppet refactor that I never got around to putting back in
- reduces deploy time for INI testing from 7 minutes to 40 seconds
