### PR TITLE
expose priority_plugins via INI settings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,7 @@
 class uber::config (
   # sideboard config file settings only below
   $sideboard_debug_enabled = false,
+  $priority_plugins = "uber",
   $hostname = $uber::hostname,
   $url_base = '%(url_root)s%(path)s',
   $socket_port = hiera('uber::socket_port'),

--- a/templates/sb-development.ini.erb
+++ b/templates/sb-development.ini.erb
@@ -3,7 +3,7 @@
 
 # defaults to 'False'
 debug = <%= @sideboard_debug_enabled %>
-priority_plugins = uber, panels
+priority_plugins = <%= @priority_plugins %>
 
 [cherrypy]
 server.socket_host = <%= @socket_host %>


### PR DESCRIPTION
Turns out we never actually exposed priority_plugins in puppet

Can't believe this wasn't being done before, hah. I just can't catch a break today :)
