### PR TITLE
Move group_discount to [badge_prices]

### DIFF
--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -83,7 +83,6 @@ show_custom_badge_input = <%= @show_custom_badge_input %>
 shirt_sales_enabled = <%= @shirt_sales_enabled %>
 show_affiliates = <%= @show_affiliates %>
 student_discount = <%= @student_discount %>
-group_discount = <%= @group_discount %>
 
 <% if @shiftless_depts -%>
 shiftless_depts = <%= @shiftless_depts %>
@@ -131,6 +130,7 @@ dealer_payment_due  = '<%= @dealer_payment_due %>'
 one_days_enabled = <%= @one_days_enabled %>
 initial_attendee = <%= @initial_attendee %>
 dealer_badge_price = <%= @dealer_badge_price %>
+group_discount = <%= @group_discount %>
 
 <% @badge_prices.each do |badge_pricing| -%>
 [[<%= badge_pricing[0] %>]]


### PR DESCRIPTION
This config option was broken because it's supposed to be in the [badge_prices] section but it was not. Moving it will fix Labs' group discount.
