### PR TITLE
Centralized logging - puppet support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -165,7 +165,8 @@ class uber::config (
   $food_stock      = undef,
   $food_price      = undef,
 
-  $log_to_stderr = false,
+  $log_to_stdout = true,
+  $log_to_syslog = false,
 ) {
 
   require uber::plugins

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -167,6 +167,7 @@ class uber::config (
 
   $log_to_stdout = true,
   $log_to_syslog = false,
+  $log_force_multiline_indent = false,
 ) {
 
   require uber::plugins

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -2,7 +2,7 @@ class uber::daemon (
   $user = hiera("uber::user"),
   $group = hiera("uber::group"),
   $daemon_name = hiera("uber::daemon_name"),
-  $app_logfile_name = hiera("uber::app_logifle_name")
+  $app_logfile_name = hiera("uber::app_logfile_name")
 ) {
   require uber::app
 

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -1,11 +1,13 @@
 class uber::daemon (
   $user = hiera("uber::user"),
-  $group = hiera("uber::group")
+  $group = hiera("uber::group"),
+  $daemon_name = hiera("uber::daemon_name"),
+  $app_logfile_name = hiera("uber::app_logifle_name")
 ) {
   require uber::app
 
   if !hiera('debugONLY_dont_init_python_or_git_repos_or_plugins') {
-    supervisor::program { 'uber_daemon' :
+    supervisor::program { $daemon_name :
       ensure        => present,
       enable        => true,
       command       => "${uber::venv_python} sideboard/run_server.py",
@@ -13,6 +15,24 @@ class uber::daemon (
       user          => $user,
       group         => $group,
       logdir_mode   => '0770',
+
+      # disable supervisor's logfile rotation in favor of system's logrotate settings
+      stdout_logfile_maxsize   => '0',
+      stdout_logfile_backups   => 0,
+      stderr_logfile_maxsize   => '0',
+      stderr_logfile_backups   => 0,
+
+      stdout_logfile => $app_logfile_name,
+      stderr_logfile => "",
+      redirect_stderr => true,
+    }
+
+    file { "/etc/logrotate.d/${daemon_name}":
+      ensure  => present,
+      owner   => "root",
+      group   => "root",
+      mode    => '0644',
+      content => template('uber/logrotate.supervisor_daemon.erb'),
     }
 
     Class["uber::app"] ~> Service["supervisor::uber_daemon"]

--- a/manifests/log-filebeat.pp
+++ b/manifests/log-filebeat.pp
@@ -14,11 +14,17 @@ class uber::log-filebeat (
           ],
           'index'       => 'filebeat'
         },
-      logging => {
-        'to_syslog' => false,
-        'to_files' => true,
+        logging         => {
+          'to_syslog' => false,
+          'to_files'  => true,
         },
       },
+    }
+
+    $multiline = {
+      pattern => '^[[:space:]]',
+      negate => false,
+      match => 'after',
     }
 
     $exclude_files = ['.gz$']
@@ -28,16 +34,22 @@ class uber::log-filebeat (
         '/var/log/syslog',
         '/var/log/auth.log',
       ],
-      doc_type      => 'syslog-beat',
+      doc_type      => 'log',
       exclude_files => $exclude_files,
+      fields        => {
+        'log_source' => 'system',
+      },
     }
 
     filebeat::prospector { 'nginxlogs':
       paths         => [
         '/var/log/nginx/*.log',
       ],
-      doc_type      => 'nginx-beat',
+      doc_type      => 'log',
       exclude_files => $exclude_files,
+      fields        => {
+        'log_source' => 'nginx',
+      },
     }
 
     filebeat::prospector { 'applogs':
@@ -45,8 +57,12 @@ class uber::log-filebeat (
         '/var/log/supervisor/*',
         "${app_logfile_name}"
       ],
-      doc_type      => 'app-beat',
+      doc_type      => 'log',
       exclude_files => $exclude_files,
+      fields        => {
+        'log_source' => 'app',
+      },
+      multiline => $multiline,
     }
   }
 }

--- a/manifests/log-filebeat.pp
+++ b/manifests/log-filebeat.pp
@@ -3,7 +3,7 @@
 class uber::log-filebeat (
   $server_name_and_port = '',
   $daemon_name = hiera("uber::daemon_name"),
-  $app_logfile_name = hiera("uber::app_logifle_name")
+  $app_logfile_name = hiera("uber::app_logfile_name")
 ) {
   if ($server_name_and_port) {
     class { 'filebeat':

--- a/manifests/log-filebeat.pp
+++ b/manifests/log-filebeat.pp
@@ -1,0 +1,52 @@
+# Uses filebeat to ship our logs out to a centralized Elastisearch server
+
+class uber::log-filebeat (
+  $server_name_and_port = '',
+  $daemon_name = hiera("uber::daemon_name"),
+  $app_logfile_name = hiera("uber::app_logifle_name")
+) {
+  if ($server_name_and_port) {
+    class { 'filebeat':
+      outputs => {
+        'elasticsearch' => {
+          'hosts'       => [
+            $server_name_and_port
+          ],
+          'index'       => 'filebeat'
+        },
+      logging => {
+        'to_syslog' => false,
+        'to_files' => true,
+        },
+      },
+    }
+
+    $exclude_files = ['.gz$']
+
+    filebeat::prospector { 'syslogs':
+      paths         => [
+        '/var/log/syslog',
+        '/var/log/auth.log',
+      ],
+      doc_type      => 'syslog-beat',
+      exclude_files => $exclude_files,
+    }
+
+    filebeat::prospector { 'nginxlogs':
+      paths         => [
+        '/var/log/nginx/*.log',
+      ],
+      doc_type      => 'nginx-beat',
+      exclude_files => $exclude_files,
+    }
+
+    filebeat::prospector { 'applogs':
+      paths         => [
+        '/var/log/supervisor/*',
+        "${app_logfile_name}"
+      ],
+      doc_type      => 'app-beat',
+      exclude_files => $exclude_files,
+    }
+  }
+}

--- a/manifests/profile_rams_full_stack.pp
+++ b/manifests/profile_rams_full_stack.pp
@@ -10,4 +10,5 @@ class uber::profile_rams_full_stack (
   require ::uber::nginx
   require ::uber::daemon
   require ::uber::firewall
+  require ::uber::log-filebeat
 }

--- a/templates/logrotate.supervisor_daemon.erb
+++ b/templates/logrotate.supervisor_daemon.erb
@@ -1,0 +1,11 @@
+<%= @app_logfile_name -%> {
+    daily
+    su root syslog
+    missingok
+    rotate 52
+    compress
+    delaycompress
+    copytruncate
+    notifempty
+    create 644 root root
+}

--- a/templates/sb-development.ini.erb
+++ b/templates/sb-development.ini.erb
@@ -19,10 +19,16 @@ server.socket_timeout = 1
 [[syslog]]
 class = "logging.handlers.SysLogHandler"
 address = "/dev/log"
+<% if @log_force_multiline_indent %>
+formatter = "indent_multiline"
+<% end -%>
 <% end -%>
 
 <% if @log_to_stdout %>
 [[stdout]]
 class = "logging.StreamHandler"
 stream = "ext://sys.stdout"
+<% if @log_force_multiline_indent %>
+formatter = "indent_multiline"
+<% end -%>
 <% end -%>

--- a/templates/sb-development.ini.erb
+++ b/templates/sb-development.ini.erb
@@ -14,12 +14,15 @@ server.thread_pool = 100
 server.socket_timeout = 1
 
 [handlers]
+
+<% if @log_to_syslog %>
 [[syslog]]
 class = "logging.handlers.SysLogHandler"
 address = "/dev/log"
+<% end -%>
 
-<% if @log_to_stderr %>
+<% if @log_to_stdout %>
 [[stdout]]
 class = "logging.StreamHandler"
-stream = "ext://sys.stderr"
+stream = "ext://sys.stdout"
 <% end -%>


### PR DESCRIPTION
Add support for us to be able to ship logs to a centralized ELK (Elastisearch+Logstash+Kibana) server.

This enables full search of all logs across any server with it enabled.  Any uber server with this enabled will send it's logging output over the network to the extremely cool Kibana search we now have setup, where we can search any aspect of log issues such as stack traces, email failures, ssh logins, deployments, and any other errors related to uber or sysadmin stuff.

Specifically we're doing a few things:
1) Setting up FileBeat which is a service that runs on the same server as sideboard and monitors the log output.  It sends log output to a central server
2) Make our log output from the sideboard app go only to stdout (not log to syslog)
3) Make supervisord capture stdout and stderr to the same log file
4) Setup logrotate rules (run once per day) that rotate our supervisor logs, thereby hopefully reducing issues of log spam causing us to run out of disk space
5) Watch the following log files: sideboard, nginx HTTP, and syslog/auth.log
6) Enable multiline indentation for sideboard, which will allow our Filebeat log parser to recognize multiline logfile output (like stack traces) as one log entry.

This stuff is installed but not enabled by default, individual puppet hiera nodes will have to turn it on by setting the elastisearch server filename.  We'll turn this on only for production servers, but also anyone can turn it on locally and do whatever.

For now this catches stacktraces and works great, however, this setup supports far more than just logging errors.  We can also collect fine-grained app-specific performance data like page load times, thread runtimes, # of sessions open, and other system data like CPU, memory, disk space, open file handles, etc, and report it back to the central server. From there, Kibana supports aggregation and we can trigger alerts based on thresholds, collect performance data over time, and monitor security threats.  In short, it's awesome.  I also already have this hooked up into slack so when enabled, it will print stack traces from any production server into #devbots_errors in our slack in realtime.

Specifically I really want this in before messing around with the Jinja2 template conversion, but also to catch template email rendering errors which only show up in the logs and we have traditionally been bad at detecting these and fixing them until weeks later.

merge with:
- https://github.com/magfest/ubersystem-deploy/pull/53

merge after:
- https://github.com/magfest/sideboard/pull/17
- https://github.com/magfest/ubersystem-deploy/pull/54 and the 5ish other pull requests referenced over there.
