### PR TITLE
replace event_location with event_venue

### DIFF
--- a/manifests/plugin_panels.pp
+++ b/manifests/plugin_panels.pp
@@ -8,7 +8,6 @@ class uber::plugin_panels (
   # INI settings below
   $hide_schedule = true,
   $expected_response = undef,
-  $event_location = undef,
   $panel_rooms = undef,
   $panel_app_deadline = undef,
 ) {

--- a/templates/panels-development.ini.erb
+++ b/templates/panels-development.ini.erb
@@ -9,10 +9,6 @@ hide_schedule = <%= @hide_schedule %>
 expected_response = "<%= @expected_response %>"
 <% end -%>
 
-<% if @event_location %>
-event_location = "<%= @event_location %>"
-<% end -%>
-
 <% if @panel_rooms %>
 panel_rooms = <%= @panel_rooms %>
 <% end -%>


### PR DESCRIPTION
- we added c.EVENT_VENUE in base uber over the summer, so it can replace the same INI setting from the panels plugin
