### PR TITLE
enable caching for nginx, also add maintenance mode

### DIFF
--- a/files/rams.conf
+++ b/files/rams.conf
@@ -1,0 +1,12 @@
+# MANAGED BY PUPPET, DO NOT EDIT
+
+# this file is included by other nginx files because we need to turn on and off caching based on various location{} tags
+# puppet notes: 'localhost' is the backend and hardcoded, but unlikely to change.
+
+# PROXY CACHING STUFF
+proxy_cache one;    # 'one' is the name/identifier of the cache
+proxy_cache_key       $host$request_uri|$request_body;
+proxy_cache_valid 200 60m;
+proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+proxy_cache_bypass $http_secret_header $arg_nocache;
+add_header X-Cache-Status $upstream_cache_status;


### PR DESCRIPTION
- overhaul nginx config to enable caching of static content from ubersystem
- greatly reduces stress on the backend server and relieves it from having to serve up static content
- add maintenance mode, if you create /var/www/maintenance.html, all pages will redirect there

merge with https://github.com/magfest/ubersystem-deploy/pull/62
