### PR TITLE
fix caching by not return a Set-Cookie header to the client

### DIFF
--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -160,6 +160,7 @@ define uber::nginx_custom_location(
       "uber-nginx-location-$name" => {
         location_custom_cfg_prepend => {
           '    proxy_ignore_headers' => 'Cache-Control Set-Cookie;',
+          '    proxy_hide_headers' => 'Set-Cookie;', # important: static requests should NOT return Set-Cookie to client
         },
       }
     }


### PR DESCRIPTION
- nginx will CACHE a Set-Cookie header, and this tells it not to send ANY Set-Cookie back to the client
- if you fail to do this, you get weird things like everyone visiting the site gets the same cookie, which is very bad
