### PR TITLE
more firewall fixes

### DIFF
--- a/manifests/profile_rams_full_stack.pp
+++ b/manifests/profile_rams_full_stack.pp
@@ -3,12 +3,15 @@
 class uber::profile_rams_full_stack (
 
 ) {
+  require ::uber::firewall
   require ::uber::permissions
   require ::uber::app
-  require ::uber::plugin_barcode
   require ::uber::db
   require ::uber::nginx
   require ::uber::daemon
-  require ::uber::firewall
   require ::uber::log-filebeat
+
+  # workaround puppet waiting to apply 'ufw enable' til later on in the process
+  # if this gives you errors later, disable it, or move ::uber::firewall to happen last in the sequence above
+  Exec['ufw-enable'] -> Class['uber::app']
 }


### PR DESCRIPTION
- fix ufw deny rule so it actually works, we deny FROM blacklist ip, not TO this ip
- add 'ufw reset' command so we actually apply everything every time
- remove plugin_barcode from being hardcoded in the profile_rams_full_stack (should be in hiera not here) which was messing with firewall
- force all firewall settings to be applied before setting up the app, which reduces the amount of time the firewall is disabled on deploys

merge with https://github.com/magfest/production-config/pull/112
