### PR TITLE
install requirements for python-prctl

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,6 +40,20 @@ class uber::install {
     }
   }
 
+  # for python-prctl
+  if defined(Package['build-essential']) == false {
+    package { 'build-essential':
+      ensure => present,
+    }
+  }
+
+  # for python-prctl
+  if defined(Package['libcap-dev']) == false {
+    package { 'libcap-dev':
+      ensure => present,
+    }
+  }
+
   class { '::python':
     # ensure   => present,
     version    => $uber::python_ver,


### PR DESCRIPTION
- prctl is a library that allows us to set the names of running threads
