### PR TITLE
fix nginx proxy settings

### DIFF
--- a/templates/root-index.html.erb
+++ b/templates/root-index.html.erb
@@ -8,7 +8,7 @@
 
 <h1>RAMS - Registration and Management System</h1>
 <p>
-    Go to <a href="/uber"><%= @event_name %> <%= @year %> RAMS</a>
+    Go to <a href="/uber/"><%= @event_name %> <%= @year %> RAMS</a>
 </p>
 
 </body>

--- a/templates/sb-development.ini.erb
+++ b/templates/sb-development.ini.erb
@@ -10,6 +10,9 @@ server.socket_host = <%= @socket_host %>
 server.socket_port = <%= @socket_port %>
 tools.sessions.timeout = 4320  # 30 days (in minutes)
 
+tools.proxy.on = True
+tools.proxy.debug = False
+
 server.thread_pool = 100
 server.socket_timeout = 1
 


### PR DESCRIPTION
- turn on cherrypy proxy tool
- now as long as you can get the SSL port, nginx will do the right thing when uber wants to redirect urls
- pass in the original IP to cherrypy so it can be recorded in the logs
- allow the possibility of wacky stuff involving tunnels and port forwarding
- allow access to VMs running on other computers (they need a Vagrantfile setting change but it works great)

fixes:
https://github.com/magfest/ubersystem/issues/1377 
https://github.com/RAMSProject/quickstart/issues/29
https://github.com/magfest/ubersystem/issues/1975

@earl7399 this will fix your long-running issues with vagrant + accessing uber on a different machine and it not playing nice
