### PR TITLE
Add packages needed for treepoem

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,6 +54,21 @@ class uber::install {
     }
   }
 
+  # for treepoem
+  if defined(Package['libjpeg-dev']) == false {
+    package { 'libjpeg-dev':
+      ensure => present,
+    }
+  }
+
+
+  # for treepoem
+  if defined(Package['ghostscript']) == false {
+    package { 'ghostscript':
+      ensure => present,
+    }
+  }
+
   class { '::python':
     # ensure   => present,
     version    => $uber::python_ver,


### PR DESCRIPTION
These packages are required on the system in order to 1) install treepoem in the first place (done via pip) and 2) actually generate QR codes.

Merge before https://github.com/magfest/ubersystem/pull/2265.