### PR TITLE
fixes #125

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 class uber::config (
   # sideboard config file settings only below
   $sideboard_debug_enabled = false,
-  $priority_plugins = "uber",
+  $priority_plugins = "uber,",
   $hostname = $uber::hostname,
   $url_base = '%(url_root)s%(path)s',
   $socket_port = hiera('uber::socket_port'),


### PR DESCRIPTION
Quoting @khyperia from #125:

> The issue is that priority_plugins is a string_list, which when it contains one element, must end with a comma (key = value,). This makes parsing the config fail when running the server on a default config.