### PR TITLE
disable at-the-con mode jobs page hack

### DIFF
--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -126,17 +126,18 @@ class uber::nginx (
     'deny'       => 'all'
   }
 
-  # disable a particular page when in "at the con mode" that was causing issues.
+  # disable a particular page when in "at the con mode" that was causing issues
+  # (javascript causing page to refresh constantly effectively DDOS'ing us)
   # after m2017, kill this. or, keep it.
-  nginx::resource::location { "at_con_mode_hack":
-    location => "/${url_prefix}/signups/jobs",
-    ensure   => present,
-    vhost    => "rams-normal",
-    notify   => Service["nginx"],
-    www_root => '/crap_ignore',
-    ssl      => true,
-    location_cfg_append => $blackhole_config,
-  }
+  #nginx::resource::location { "at_con_mode_hack":
+  #  location => "/${url_prefix}/signups/jobs",
+  #  ensure   => present,
+  #  vhost    => "rams-normal",
+  #  notify   => Service["nginx"],
+  #  www_root => '/crap_ignore',
+  #  ssl      => true,
+  #  location_cfg_append => $blackhole_config,
+  #}
 
   if ($ssl_ca_crt != undef) {
     ensure_resource('file', "${nginx::params::conf_dir}/jsonrpc-client.crt", {


### PR DESCRIPTION
we had some javascript code in the jobs page that if users left the page at home enabled, would attempt to continually connect over and over again.

this hack disabled the page from the nginx side, keeping things running.

I believe @EliAndrewC actually did fix the real bug now so the javascript will only check once every couple of seconds, and then back off, rather than continue to hammer the page. (eli, do you have the bug# for that? trying to keep this info together so if we're onsite and looking at a similar problem we can trace it all quickly)