### PR TITLE
Make the Magstock config plugin match other plugins

### DIFF
--- a/manifests/plugin_magstock.pp
+++ b/manifests/plugin_magstock.pp
@@ -15,6 +15,11 @@ class uber::plugin_magstock (
   $camping_types = undef,
   $coming_as_types = undef,
 ) {
+  uber::repo { "${uber::plugins_dir}/magstock":
+    source   => $git_repo,
+    revision => $git_branch,
+    require  => File["${uber::plugins_dir}"],
+  }
 
   file { "${uber::plugins_dir}/magstock/development.ini":
     ensure  => present,


### PR DESCRIPTION
This is largely a style change. Goes with https://github.com/magfest/production-config/pull/194.