### PR TITLE
Adds an nginx location for /profiler/ to view cherrypy profiler stats

### DIFF
--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -103,6 +103,16 @@ class uber::nginx (
     proxy_set_header => $proxy_set_header,
   }
 
+  # adds a root "location /profiler/" for viewing of cherrypy profiler stats
+  uber::nginx_custom_location { "rams_backend-profiler-dontcache":
+    url_prefix       => "profiler",
+    backend_base_url => $backend_base_url,
+    vhost            => "rams-normal",
+    subdir           => "",
+    cached           => false,
+    proxy_set_header => $proxy_set_header,
+  }
+
   uber::nginx_custom_location { "rams_backend-static-cached":
     url_prefix       => $url_prefix,
     backend_base_url => $backend_base_url,


### PR DESCRIPTION
Ok, I have no idea what I'm doing. I believe this change will add a new location to the our nginx deployment configuration which supports urls like:
```
https://servername/profiler/
```

I'm adding support for the [cherrypy profiling tools](http://docs.cherrypy.org/en/latest/_modules/cherrypy/lib/profiler.html) to sideboard like this:
![screen shot 2017-05-05 at 5 40 01 pm](https://cloud.githubusercontent.com/assets/2592431/25765241/f3298b7e-31b9-11e7-9067-1959ddd629e1.png)
