### PR TITLE
Add "api_enabled" config value and default to true

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class uber::config (
   #$group_reg_open = True,
   $send_emails = false,
   $use_checkin_barcode = true,
+  $api_enabled = true,
   $aws_access_key = '',
   $aws_secret_key = '',
   # Test stripe keys associated with our test stripe account

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -7,6 +7,7 @@ hostname = "<%= @hostname %>"
 dev_box = <%= @dev_box %>
 send_emails = <%= @send_emails %>
 use_checkin_barcode = <%= @use_checkin_barcode %>
+api_enabled = <%= @api_enabled %>
 collect_exact_birthdate = <%= @collect_exact_birthdate %>
 event_name = "<%= @event_name %>"
 organization_name = "<%= @organization_name %>"
@@ -16,7 +17,7 @@ event_qr_id = "<%= @event_qr_id %>"
 hardcore_optimizations_enabled = "<%= @hardcore_optimizations_enabled %>"
 
 event_venue = "<%= @event_venue %>"
-event_venue_address = "<%= @event_venue_address %>"
+event_venue_address = "<%=@event_venue_address %>"
 
 groups_enabled = <%= @groups_enabled %>
 kiosk_cc_enabled = <%= @kiosk_cc_enabled %>

--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -17,7 +17,7 @@ event_qr_id = "<%= @event_qr_id %>"
 hardcore_optimizations_enabled = "<%= @hardcore_optimizations_enabled %>"
 
 event_venue = "<%= @event_venue %>"
-event_venue_address = "<%=@event_venue_address %>"
+event_venue_address = "<%= @event_venue_address %>"
 
 groups_enabled = <%= @groups_enabled %>
 kiosk_cc_enabled = <%= @kiosk_cc_enabled %>


### PR DESCRIPTION
MAGFest events use the API a lot, but other events would want it hidden by default. Since it defaults to False in configspec.ini (correct behavior), we want to set it to true in our puppet manifest.