### PR TITLE
Fixes #2699: Adds dealer_registration page to nginx cache

### DIFF
--- a/files/rams-microcache.conf
+++ b/files/rams-microcache.conf
@@ -6,10 +6,10 @@
 # PROXY CACHING STUFF
 proxy_cache               one;
 proxy_cache_key           $host$request_uri;
-proxy_cache_valid         200 10s;  # Only keep cache valid for 10s
+proxy_cache_valid         200 20s;  # Only keep cache valid for 20s
 proxy_cache_lock          on;   # Subsequent requests must wait for the first request to be cached
-proxy_cache_lock_age      30s;  # Wait for 30s for the first request before bypassing cache
-proxy_cache_lock_timeout  30s;
+proxy_cache_lock_age      40s;  # Wait for 40s for the first request before bypassing cache
+proxy_cache_lock_timeout  40s;
 proxy_cache_use_stale     error timeout invalid_header updating http_500 http_502 http_503 http_504;
 proxy_cache_bypass        $http_secret_header $cookie_nocache $arg_nocache $args;
 proxy_no_cache            $http_secret_header $cookie_nocache $arg_nocache $args;

--- a/manifests/nginx.pp
+++ b/manifests/nginx.pp
@@ -121,6 +121,17 @@ class uber::nginx (
     proxy_set_header  => $proxy_set_header,
   }
 
+  # adds microcaching for "location /uber/preregistration/dealer_registration"
+  uber::nginx_custom_location { "rams_backend-dealer-registration-microcache":
+    url_prefix        => $url_prefix,
+    backend_base_url  => $backend_base_url,
+    vhost             => "rams-normal",
+    subdir            => "preregistration/dealer_registration",
+    microcached       => true,
+    location_modifier => "=",
+    proxy_set_header  => $proxy_set_header,
+  }
+
   # adds a root "location /profiler/" for viewing of cherrypy profiler stats
   uber::nginx_custom_location { "rams_backend-profiler-dontcache":
     url_prefix       => "profiler",


### PR DESCRIPTION
Fixes magfest/ubersystem/issues/2699: Adds dealer_registration page to nginx cache, also bumps cache expiration from 10s to 20s.

The "preregistration/dealer_registration" template is actually an extension of the "preregistration/form" template, so it POSTs to the same url, and the caching works in exactly the same way.