### PR TITLE
fix bug where vars being set False would skip these blocks

### DIFF
--- a/templates/uber-development.ini.erb
+++ b/templates/uber-development.ini.erb
@@ -82,11 +82,11 @@ at_the_con = "<%= @at_the_con %>"
 post_con = "<%= @post_con %>"
 out_of_shirts = "<%= @out_of_shirts %>"
 
-<% if @shirts_per_staffer -%>
+<% unless @shirts_per_staffer.nil? -%>
 shirts_per_staffer = <%= @shirts_per_staffer %>
 <% end -%>
 
-<% if @staff_eligible_for_swag_shirt -%>
+<% unless @staff_eligible_for_swag_shirt.nil? -%>
 staff_eligible_for_swag_shirt = <%= @staff_eligible_for_swag_shirt %>
 <% end -%>
 


### PR DESCRIPTION
i -think- this will do it, worked in a local ruby test

we will probably need to do a pass over the entire file and use this format instead of the ```if``` statements we'd been using.