### PR TITLE
Sets up a permanent plugin directory rename from "bands" to "guests" during our puppet deploy

### DIFF
--- a/manifests/plugin_guests.pp
+++ b/manifests/plugin_guests.pp
@@ -22,6 +22,25 @@ class uber::plugin_guests (
   $band_badges_deadline = '',
   $band_stage_plot_deadline = '',
 ) {
+
+  # The following two "file" definitions rename an existing "bands" plugin
+  # directory to "guests". This will absolutely break if we ever create
+  # another plugin named "bands".
+
+  file { "${uber::plugins_dir}/guests":
+    ensure  => 'directory',
+    source  => "file://${uber::plugins_dir}/bands",
+    recurse => true,
+    before  => File["${uber::plugins_dir}/bands"],
+  }
+
+  file { "${uber::plugins_dir}/bands":
+    ensure  => 'absent',
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
+
   uber::repo { "${uber::plugins_dir}/guests":
     source   => $git_repo,
     revision => $git_branch,


### PR DESCRIPTION
Since we've already manually deleted the "bands" directory on staging4, we can't test the guests plugin deployment on that server anymore.

I propose testing this on our other staging servers, each in turn once we've verified it works on the previous: staging1, staging2, and finally staging3.

# Test Procedure

1. **BEFORE** running a deploy, create a new band and upload bio pics, stage plots, and a fake W9
2. Verify the files are viewable/downloadable
3. Run the deploy for that server
4. Verify the same files are still viewable/downloadable
5. Verify the "bands" plugin directory does NOT exist and the "guests" plugin directory DOES exist (need to ssh to the server for this part)
6. Run the deploy for that server *again*
7. Verify the deploy is successful
8. Verify the same files are still viewable/downloadable

Once all of those steps have been verified, we can move on to the next staging server.

Once we have verified this works on staging1, staging2, and staging3, we should also verify we can still deploy to staging4. (Want to make sure we didn't break that server by manually deleting the bands directory)

Once we've verified everything is working with all the staging servers, then we can try deploying to our production servers. First magstock, then magwest, then maglabs, and finally super. For each we must verify that uploaded band files exist and are viewable both **BEFORE** and after the deploy.