### PR TITLE
Updates admin_email to code@magfest.org

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -157,12 +157,12 @@ class uber::config (
   $marketplace_sig = " - Danielle Pomfrey,\nMAGFest Marketplace Coordinator",
   $peglegs_sig = " - Tim Macneil,\nMAGFest Panels Department",
   $guest_sig = " - Steph Prader,\nMAGFest Guest Coordinator",
-  $admin_email = "Eli Courtwright <eli@courtwright.org>",
+  $admin_email = "MAGFest Software <code@magfest.org>",
   $regdesk_email = "MAGFest Registration <regdesk@magfest.org>",
   $staff_email = "MAGFest Staffing <stops@magfest.org>",
   $marketplace_email = "MAGFest Marketplace <marketplace@magfest.org>",
   $panels_email = "MAGFest Panels <panels@magfest.org>",
-  $developer_email = "Eli Courtwright <code@magfest.org>",
+  $developer_email = "MAGFest Software <code@magfest.org>",
 
   $supporter_stock = undef,
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -157,7 +157,7 @@ class uber::config (
   $marketplace_sig = " - Danielle Pomfrey,\nMAGFest Marketplace Coordinator",
   $peglegs_sig = " - Tim Macneil,\nMAGFest Panels Department",
   $guest_sig = " - Steph Prader,\nMAGFest Guest Coordinator",
-  $admin_email = "MAGFest Software <code@magfest.org>",
+  $admin_email = "MAGFest Sys Admins <sysadmin@magfest.org>",
   $regdesk_email = "MAGFest Registration <regdesk@magfest.org>",
   $staff_email = "MAGFest Staffing <stops@magfest.org>",
   $marketplace_email = "MAGFest Marketplace <marketplace@magfest.org>",


### PR DESCRIPTION
We currently send critical exceptions to `c.ADMIN_EMAIL`, which only went to Eli. We probably want to use code@magfest.org (or something else?) for our admin email address.